### PR TITLE
CI: Build images with GitHub Actions

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -1,0 +1,115 @@
+name: "Build and Push"
+
+inputs:
+  VERSION_MAJOR:
+    required: true
+  IMAGE_REGISTRY:
+    required: true
+  REGISTRY_USER:
+    required: true
+  REGISTRY_PASSWORD:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare environment
+      shell: bash
+      run: |
+        # Date stamp
+        DATE_STAMP=$(date -u '+%Y%m%d')
+        [ "x${DATE_STAMP}" != "x" ] && echo "DATE_STAMP=${DATE_STAMP}" >> "$GITHUB_ENV"
+
+        # Platform / arch
+        platform="${{ env.PLATFORM }}"
+        ARCH=${platform#linux/}
+        [ "x${ARCH}" != "x" ] && echo "ARCH=${ARCH}" >> "$GITHUB_ENV"
+
+        # Platform / machine
+        MACHINE=x86_64
+        [ "$ARCH" = "arm64" ] && MACHINE=aarch64
+        echo "MACHINE=${MACHINE}" >> "$GITHUB_ENV"
+
+        # Minor version
+        release=$(rpm -q --qf="%{VERSION}\n" https://repo.almalinux.org/almalinux/almalinux-release-latest-${{ inputs.VERSION_MAJOR }}.${MACHINE}.rpm 2>/dev/null)
+        VERSION_MINOR=$(cut -d '.' -f 2 <<< "$release")
+        [ "x${VERSION_MINOR}" != "x" ] && echo "VERSION_MINOR=${VERSION_MINOR}" >> "$GITHUB_ENV"
+
+        # quay.io/almalinuxorg/almalinux-bootc
+        IMAGE_DEST=${{ inputs.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+        echo "IMAGE_DEST=${IMAGE_DEST}" >> "$GITHUB_ENV"
+
+    - name: Check update
+      shell: bash
+      run: |
+        # 'dnf check-update'
+        # exit codes:
+        #   0 - no updates
+        #   100 - updates available
+        #   125 - tag/platform not found
+        res=0
+        docker run --quiet --rm ${{ inputs.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.VERSION_MAJOR }} dnf check-update || res=$?
+        echo "res=${res}" >> "$GITHUB_ENV"
+        echo "Exit code: '$res'"
+
+    - name: Build image
+      if: ${{ env.res != 0 }}
+      shell: bash
+      run: |
+        podman build \
+          --platform=${{ env.PLATFORM }} \
+          --security-opt=label=disable \
+          --cap-add=all \
+          --device /dev/fuse \
+          -t ${{ env.IMAGE_NAME }} \
+          -f ${{ inputs.VERSION_MAJOR }}/Containerfile \
+        .
+
+    - name: Run Image
+      if: ${{ env.res != 0 }}
+      shell: bash
+      run: podman run --rm -ti ${{ env.IMAGE_NAME }} bootc --version
+
+    - name: Log in to registry
+      if: ${{ env.res != 0 }}
+      shell: bash
+      run: podman login ${{ inputs.IMAGE_REGISTRY }} -u ${{ inputs.REGISTRY_USER }} -p ${{ inputs.REGISTRY_PASSWORD }}
+
+    - name: Push to registry
+      if: ${{ env.res != 0 }}
+      shell: bash
+      run: |
+        # Tag: VERSION_MAJOR.VERSION_MINOR-DATE_STAMP-ARCH
+        podman push ${{ env.IMAGE_NAME }} \
+          docker://${IMAGE_DEST}:${{ inputs.VERSION_MAJOR }}.${{ env.VERSION_MINOR }}-${{ env.DATE_STAMP }}-${{ env.ARCH }}
+
+    - name: Login to registry (docker)
+      if: ${{ env.res != 0 }}
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.IMAGE_REGISTRY }}
+        username: ${{ inputs.REGISTRY_USER }}
+        password: ${{ inputs.REGISTRY_PASSWORD }}
+
+    - name: Create and push manifest (docker)
+      if: ${{ env.res != 0 }}
+      shell: bash
+      run:  |
+        # Manifest for both amd64 and arm64
+        second_arch=amd64
+        [ "${{ env.ARCH  }}" = "amd64" ] && second_arch=arm64
+
+        second_manifest=''
+        docker manifest inspect ${{ env.IMAGE_DEST}}:${{ inputs.VERSION_MAJOR }}.${{ env.VERSION_MINOR }}-${{ env.DATE_STAMP }}-${second_arch} >/dev/null 2>&1 \
+          && second_manifest=${{ env.IMAGE_DEST}}:${{ inputs.VERSION_MAJOR }}.${{ env.VERSION_MINOR }}-${{ env.DATE_STAMP }}-${second_arch}
+
+        # Loop over need tags: latest, VERSION_MAJOR, VERSION_MAJOR.VERSION_MINOR, VERSION_MAJOR.VERSION_MINOR-DATE_STAMP
+        for tag in latest ${{ inputs.VERSION_MAJOR }} ${{ inputs.VERSION_MAJOR }}.${{ env.VERSION_MINOR }} ${{ inputs.VERSION_MAJOR }}.${{ env.VERSION_MINOR }}-${{ env.DATE_STAMP }}; do
+            [ ${{ inputs.VERSION_MAJOR }} != ${{ env.LATEST_MAJOR }} -a "${tag}" = "latest" ] && continue
+
+            docker manifest create ${IMAGE_DEST}:${tag} \
+              ${{ env.IMAGE_DEST}}:${{ inputs.VERSION_MAJOR }}.${{ env.VERSION_MINOR }}-${{ env.DATE_STAMP }}-${{ env.ARCH }} ${second_manifest}
+
+            docker manifest inspect ${{ env.IMAGE_DEST }}:${tag}
+
+            docker manifest push ${{ env.IMAGE_DEST }}:${tag}
+        done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,58 +1,108 @@
-name: Build
-on: [push]
-
+name: Build amd64 and arm64
+on:
+  workflow_dispatch:
+  schedule:
+    # run Mon, Wed, Fri at 03:00 UTC
+    - cron:  '00 03 * * 1,3,5'
 
 env:
   LATEST_MAJOR: 9
   IMAGE_NAME: almalinux-bootc
-
+  VERSIONS_LIST: '"9"' # '"9", "10"'
 
 jobs:
-  build:
+  set-versions-matrix:
+    name: Set versions matrix
     runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: echo "matrix=[${{ env.VERSIONS_LIST }}]" >> $GITHUB_OUTPUT
+
+  build-amd64:
+    name: amd64 '${{ matrix.VERSION_MAJOR}}' image
+    runs-on: ubuntu-24.04
+    needs: [set-versions-matrix]
     strategy:
+      fail-fast: false
       matrix:
-        platform: [linux/amd64]
-        include:
-          - major: 9
-            minor: 9.4
+        VERSION_MAJOR: ${{ fromJSON(needs.set-versions-matrix.outputs.matrix) }}
+    env:
+      PLATFORM: linux/amd64
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
 
+    - uses: ./.github/actions/shared-steps
+      name: Build and Push
+      with:
+        VERSION_MAJOR: ${{ matrix.VERSION_MAJOR }}
+        IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
+        REGISTRY_USER:  ${{ secrets.REGISTRY_USER }}
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+
+  start-arm64-runner:
+    timeout-minutes: 10              # normally it only takes 1-2 minutes
+    name: arm64 self-hosted runner for '${{ matrix.VERSION_MAJOR}}'
+    runs-on: ubuntu-24.04
+    needs: [set-versions-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        VERSION_MAJOR: ${{ fromJSON(needs.set-versions-matrix.outputs.matrix) }}
+
+    steps:
+    - name: Setup and start the runner
+      id: start-ec2-runner
+      uses: NextChapterSoftware/ec2-action-builder@v1.5
+      with:
+        github_token: ${{ secrets.GIT_HUB_TOKEN }}
+        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws_region: ${{ secrets.AWS_REGION }}
+        ec2_ami_id: ${{ matrix.VERSION_MAJOR == '9' && secrets.EC2_AMI_ID_AL9 }}
+        ec2_subnet_id: ${{ secrets.EC2_SUBNET_ID}}
+        ec2_security_group_id: ${{ secrets.EC2_SECURITY_GROUP_ID }}
+
+        ec2_instance_type: t4g.medium       # 2 vCPU and 4 GiM Memory
+        ec2_root_disk_size_gb: "16"         # override default size which is too small for images
+        ec2_root_disk_ebs_class: "gp3"      # use faster and cheeper storage instead of default 'gp2'
+        ec2_instance_ttl: 60                # Optional (default is 60 minutes)
+        ec2_spot_instance_strategy: None    # Other options are: SpotOnly, BestEffort, MaxPerformance
+        ec2_instance_tags: >                # Required for IAM role resource permission scoping
+          [
+              {"Key": "Project", "Value": "GitHub Actions Self-hosted Runners"}
+          ]
+
+  build-arm64:
+    name: arm64 '${{ matrix.VERSION_MAJOR}}' image
+    runs-on: ${{ github.run_id }}
+    needs: [set-versions-matrix, start-arm64-runner]
+    strategy:
+      fail-fast: false
+      matrix:
+        VERSION_MAJOR: ${{ fromJSON(needs.set-versions-matrix.outputs.matrix) }}
+    env:
+      PLATFORM: linux/arm64
+
+    steps:
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install -y podman
+        sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+        sudo yum -y -q install docker-ce docker-ce-cli containerd.io podman git
+        sudo systemctl start docker
 
-    - name: Build image
-      id: build-image
-      run: |
-        git submodule init
-        git submodule update
-        podman build \
-          --platform=${{ matrix.platform }} \
-          --security-opt=label=disable \
-          --cap-add=all \
-          --device /dev/fuse \
-          -t ${{ env.IMAGE_NAME }} \
-          -f ${{ matrix.major }}/Containerfile \
-          .
-
-    - name: Log in to registry
-      uses: redhat-actions/podman-login@v1
+    - uses: actions/checkout@v4
       with:
-        username: ${{ secrets.REGISTRY_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-        registry: ${{ secrets.IMAGE_REGISTRY }}
+        submodules: true
 
-    - name: Push To registry
-      run: |
-        export IMAGE_DEST=docker://${{ secrets.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-        export DATE_STAMP=$(date -u '+%Y%m%d')
-
-        podman push ${{ env.IMAGE_NAME }} ${IMAGE_DEST}:${{ matrix.major }}
-        podman push ${{ env.IMAGE_NAME }} ${IMAGE_DEST}:${{ matrix.minor }}
-        podman push ${{ env.IMAGE_NAME }} ${IMAGE_DEST}:${{ matrix.minor }}-${DATE_STAMP}
-
-        [ ${{ matrix.major }} = ${{ env.LATEST_MAJOR }} ]; podman push ${{ env.IMAGE_NAME }} ${IMAGE_DEST}:latest
+    - uses: ./.github/actions/shared-steps
+      name: Build and Push
+      with:
+        VERSION_MAJOR: ${{ matrix.VERSION_MAJOR }}
+        IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
+        REGISTRY_USER:  ${{ secrets.REGISTRY_USER }}
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/9/Containerfile
+++ b/9/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/almalinuxorg/9-base:9.4 as repos
+FROM quay.io/almalinuxorg/9-base:9 as repos
 FROM quay.io/centos-bootc/bootc-image-builder:latest as builder
 
 


### PR DESCRIPTION
- build arm64 images
- use EC2 self-hosted runner to build for arm64
- use composit GitHub actions (.github/actions/shared-steps/action.yml) to share and reuse steps within workflow's dirrefent jobs
- create and push multi-architecture manifest (with docker)
- use separete step to set AlmaLinux releases matrix
- run workflow manually and by schedule (00 03 * * 1,3,5)
- run 'dnf check-update' to determine necessety of new image building