### PR TITLE
CI: Stub podman on version 5.3.1-3.el10. Kitten build on arm64 fails with its newer versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,10 +138,24 @@ jobs:
     - name: Install dependencies (${{ env.VERSION_MAJOR }})
       run: |
         sudo yum -y -q update
-        # TODO: with newer version of podman 9-th build fails with:
-        #   [3/3] STEP 1/2: FROM oci-archive:./out.ociarchive
-        #   Error: creating build container: creating temp directory: archive file not found: "/actions-runner/_work/bootc-images/bootc-images/out.ociarchive"
-        sudo yum -y -q install ${{ env.VERSION_MAJOR == '9' && 'podman-5.2.2-11.el9_5' || 'podman' }} git
+        case ${{ env.VERSION_MAJOR }} in
+          9)
+            # TODO: with newer version of podman 9-th build fails with:
+            #   [3/3] STEP 1/2: FROM oci-archive:./out.ociarchive
+            #   Error: creating build container: creating temp directory: archive file not found: "/actions-runner/_work/bootc-images/bootc-images/out.ociarchive"
+            podman=podman-5.2.2-11.el9_5
+            ;;
+          10-kitten)
+            # TODO: with newer version of podman Kitten build fails with:
+            #  [2/3] STEP 8/8: RUN --mount=type=cache,target=/workdir --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared rpm-ostree compose image --image-config almalinux-bootc-config.json --cachedir=/workdir --format=ociarchive --initialize almalinux-bootc.yaml /buildcontext/out.ociarchive
+            #  Error: resolving mountpoints for container "a9060942cbd49baba612a98c83079c57a29d1b4ddf8b678367d43005bc8c1e32": rw: must not provide an argument for option
+            podman=podman-5.3.1-3.el10
+            ;;
+          10)
+            podman=podman
+            ;;
+        esac
+        sudo yum -y -q install ${podman} git
 
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
[2/3] STEP 8/8: RUN --mount=type=cache,target=/workdir --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared rpm-ostree compose image --image-config almalinux-bootc-config.json --cachedir=/workdir --format=ociarchive --initialize almalinux-bootc.yaml /buildcontext/out.ociarchive
 Error: resolving mountpoints for container "a9060942cbd49baba612a98c83079c57a29d1b4ddf8b678367d43005bc8c1e32": rw: must not provide an argument for option