### PR TITLE
fix: bump redhat.version-id to 9.5

### DIFF
--- a/9/almalinux-bootc-config.json
+++ b/9/almalinux-bootc-config.json
@@ -3,7 +3,7 @@
         "containers.bootc": "1",
         "bootc.diskimage-builder": "quay.io/centos-bootc/bootc-image-builder",
         "redhat.id": "almalinux",
-        "redhat.version-id": "9.4"
+        "redhat.version-id": "9.5"
     },
     "StopSignal": "SIGRTMIN+3"
 }


### PR DESCRIPTION
Probably should pay more attention to it in the future.