### PR TITLE
Use bootc-base-imagectl

### DIFF
--- a/10-kitten/Containerfile
+++ b/10-kitten/Containerfile
@@ -1,27 +1,35 @@
 FROM docker.io/library/almalinux:10-kitten as repos
-FROM quay.io/centos-bootc/bootc-image-builder:latest as builder
+FROM quay.io/centos-bootc/centos-bootc:stream10 as builder
 
+COPY 10-kitten/almalinux-bootc.yaml /usr/share/doc/bootc-base-imagectl/manifests/
 
-COPY --from=repos /etc/dnf/vars /etc/dnf/vars
+RUN --mount=type=bind,rw,from=repos,src=/,dst=/repos \
+    /usr/libexec/bootc-base-imagectl build-rootfs \
+        --reinject \
+        --manifest=almalinux-bootc \
+        /repos \
+        /target-rootfs
 
-COPY 10-kitten /src
-COPY fedora-bootc /src/fedora-bootc
-WORKDIR /src
-
-COPY --from=repos /etc/yum.repos.d/*.repo /src
-COPY --from=repos /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10 /etc/pki/rpm-gpg
-
-RUN --mount=type=cache,target=/workdir \
-    --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared \
-    rpm-ostree compose image \
-        --image-config almalinux-bootc-config.json \
-        --cachedir=/workdir \
-        --format=ociarchive \
-        --initialize almalinux-bootc.yaml \
-        /buildcontext/out.ociarchive
+RUN --mount=type=bind,rw,src=.,dst=/buildcontext,bind-propagation=shared \
+    rpm-ostree experimental compose build-chunked-oci \
+        --bootc \
+        --format-version=1 \
+        --rootfs /target-rootfs \
+        --output oci-archive:/buildcontext/out.ociarchive
 
 FROM oci-archive:./out.ociarchive
 
 RUN --mount=type=bind,from=builder,src=.,target=/var/tmp \
     --mount=type=bind,rw=true,src=.,dst=/buildcontext,bind-propagation=shared \
     rm /buildcontext/out.ociarchive
+
+# EL compat labels
+LABEL containers.bootc="1" \
+      ostree.bootable="1" \
+      org.opencontainers.image.version="10" \
+      redhat.id="almalinux" \
+      redhat.version-id="10"
+ENV container=oci
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/sbin/init"]

--- a/10-kitten/almalinux-bootc-config.json
+++ b/10-kitten/almalinux-bootc-config.json
@@ -1,9 +1,0 @@
-{
-    "Labels": {
-        "containers.bootc": "1",
-        "bootc.diskimage-builder": "quay.io/centos-bootc/bootc-image-builder",
-        "redhat.id": "almalinux",
-        "redhat.version-id": "10.0"
-    },
-    "StopSignal": "SIGRTMIN+3"
-}

--- a/10-kitten/almalinux-bootc.yaml
+++ b/10-kitten/almalinux-bootc.yaml
@@ -1,15 +1,7 @@
-releasever: 10
-
-repos:
-  - baseos
-  - appstream
-
-variables:
-  distro: "almalinux10"
-
 packages:
-  #- almalinux-repos
-  - almalinux-kitten-repos
+  # EL compat
+  - dnf-yum
+  - dnf-bootc
 
 postprocess:
   - |
@@ -21,5 +13,4 @@ postprocess:
     EOF
 
 include:
-  - fedora-bootc/tier-1/kernel.yaml
-  - fedora-bootc/tier-1/manifest.yaml
+  - standard/manifest.yaml


### PR DESCRIPTION
CentOS introduced `bootc-base-imagectl`, which simplifies the process of generating custom base images.
This allows users to create custom *base* bootc images without needing to fork this repo.
I believe AlmaLinux should also include this tool in its bootc image.
https://docs.fedoraproject.org/en-US/bootc/building-custom-base/

Note:
- This does not fix the build issue with newer versions of podman. https://github.com/AlmaLinux/bootc-images/blob/d05e2634f01b5c708b1770c913c7b7c72d7d0ab2/.github/workflows/build.yml#L149
  - In theory, the rechunking process could be moved outside of the Containerfile.