### PR TITLE
Sign images

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -11,6 +11,8 @@ inputs:
     required: true
   REGISTRY_PASSWORD:
     required: true
+  SIGNING_SECRET:
+    required: false
 runs:
   using: "composite"
   steps:
@@ -30,7 +32,11 @@ runs:
     - name: Log in to registry
       if: ${{ env.res != 0 || github.event_name == 'workflow_dispatch' }}
       shell: bash
-      run: sudo podman login ${{ inputs.IMAGE_REGISTRY }} -u ${{ inputs.REGISTRY_USER }} -p ${{ inputs.REGISTRY_PASSWORD }}
+      run: |
+        sudo podman login ${{ inputs.IMAGE_REGISTRY }} -u ${{ inputs.REGISTRY_USER }} -p ${{ inputs.REGISTRY_PASSWORD }}
+
+        # This is needed by cosign
+        sudo docker login ${{ inputs.IMAGE_REGISTRY }} -u ${{ inputs.REGISTRY_USER }} -p ${{ inputs.REGISTRY_PASSWORD }}
 
     - name: Check update
       shell: bash
@@ -132,7 +138,21 @@ runs:
           docker://${IMAGE_DEST}:${{ env.VERSION }}-${{ inputs.DATE_STAMP }}-${{ env.CLEAN_ARCH }}
 
         echo "digest=$(cat /tmp/digestfile)" >> $GITHUB_OUTPUT
+        echo "image-ref=${IMAGE_DEST}:${{ env.VERSION }}-${{ inputs.DATE_STAMP }}-${{ env.CLEAN_ARCH }}" >> $GITHUB_OUTPUT
         sudo podman inspect ${{ env.IMAGE_ID }}
+
+    - name: Install Cosign
+      if: ${{ github.event_name != 'pull_request' && (env.res != 0 || github.event_name == 'workflow_dispatch') }}
+      uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+      with:
+        install-dir: '/tmp/.cosign'
+
+    - name: Sign Image
+      if: ${{ github.event_name != 'pull_request' && (env.res != 0 || github.event_name == 'workflow_dispatch') }}
+      shell: bash
+      run: |
+        echo "${{ inputs.SIGNING_SECRET }}" > /tmp/.cosign/cosign.key
+        sudo /tmp/.cosign/cosign sign -y --key /tmp/.cosign/cosign.key ${{ steps.push.outputs.image-ref }}@${{ steps.push.outputs.digest }}
 
     - name: Create Job Outputs
       if: ${{ env.res != 0 || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
         IMAGE_REGISTRY: ${{ secrets.IMAGE_REGISTRY }}
         REGISTRY_USER:  ${{ secrets.REGISTRY_USER }}
         REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
 
   push-manifest:
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') }}
@@ -98,6 +99,9 @@ jobs:
       DATE_STAMP: ${{ needs.set-versions-matrix.outputs.date_stamp }}
 
     steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+
       - name: Login to registry (docker)
         uses: docker/login-action@v3
         with:
@@ -213,11 +217,15 @@ jobs:
         env:
           MANIFEST: ${{ steps.create-manifest.outputs.MANIFEST }}
           TAGS: ${{ steps.metadata.outputs.tags }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
         run: |
           IMAGE_DEST=${{ secrets.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           while IFS= read -r tag; do
             podman manifest push --all=false --digestfile=/tmp/digestfile $MANIFEST ${IMAGE_DEST}:$tag
           done <<< "$TAGS"
+
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_DEST}:${tag}
 
           DIGEST=$(cat /tmp/digestfile)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR signs the generated images using [Sigstore's Cosign](https://docs.sigstore.dev/).

Before merging, a key needs to be generated using the following procedure:

1) Generate a cosign key:
  `podman run --rm -it -v /tmp:/cosign-keys bitnami/cosign generate-key-pair --output-key-prefix almalinux-bootc`
  Hit enter when asked for a private key password (that is, don't set a password). Once complete, you'll find the new key in `/tmp/almalinux-bootc.{key,pub}` on your machine.

2) Add `almalinux-bootc.pub` to this repository as `/almalinux-bootc.pub`, commit and push. Feel free to publish this file in other places too, it will be needed by everyone to verify the signature of the published images.

3) In the [github repo settings](https://github.com/AlmaLinux/bootc-images/settings), go to "Secrets and variables" in the "Security" subsection and click on "Actions". Create a new Repository secret called "SIGNING_SECRET" and paste the contents of `almalinux-bootc.key`.

4) Store `almalinux-bootc.key` in a secure place and delete it from your /tmp directory.