### PR TITLE
Rechunk image and reinject imagectl into the base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,10 @@ on:
         default: '9'
         type: choice
         options:
-          - 10-kitten
-          - 10
-          - 9
+          - '10-kitten'
+          - '10'
+          - '9'
+          - 'ALL'
 
   schedule:
     # run every day at 03:00 UTC
@@ -35,7 +36,11 @@ jobs:
           # Format json for versions matrix
           case ${{ github.event_name }} in
             workflow_dispatch)
-              echo "matrix=$(jq -c <<< '["${{ inputs.RELEASE }}"]')" >> $GITHUB_OUTPUT
+              if [[ "${{ inputs.RELEASE }}" == "ALL" ]]; then
+                echo "matrix=$(jq -c <<< '[${{ env.VERSIONS_LIST }}]')" >> $GITHUB_OUTPUT
+              else
+                echo "matrix=$(jq -c <<< '["${{ inputs.RELEASE }}"]')" >> $GITHUB_OUTPUT
+              fi
               ;;
             schedule)
               echo "matrix=$(jq -c <<< '[${{ env.VERSIONS_LIST }}]')" >> $GITHUB_OUTPUT
@@ -123,8 +128,6 @@ jobs:
             release=${{ matrix.VERSION_MAJOR }}
             if [[ "${{ matrix.VERSION_MAJOR }}" != *'kitten'* ]]; then
               almalinux_release=https://repo.almalinux.org/almalinux/almalinux-release-latest-${{ matrix.VERSION_MAJOR }}.${MACHINE}.rpm
-              # TODO: remove when AlmaLinux 10.0 is released
-              [ "${{ matrix.VERSION_MAJOR }}" = "10" ] && almalinux_release=https://vault.almalinux.org/almalinux-release-latest-10-beta.${MACHINE}.rpm
               release=$(rpm -q --qf="%{VERSION}\n" ${almalinux_release} 2>/dev/null)
               VERSION_MINOR=.$(cut -d '.' -f 2 <<< "$release")
             fi

--- a/10-kitten/Containerfile
+++ b/10-kitten/Containerfile
@@ -9,7 +9,7 @@ COPY --from=repos /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10 /etc/pki/rpm-gpg
 
 COPY 10-kitten/almalinux-10-kitten.yaml /usr/share/doc/bootc-base-imagectl/manifests/
 
-RUN /usr/libexec/bootc-base-imagectl build-rootfs --manifest=almalinux-10-kitten /target-rootfs
+RUN /usr/libexec/bootc-base-imagectl build-rootfs --reinject --manifest=almalinux-10-kitten /target-rootfs
 
 ###
 
@@ -19,6 +19,6 @@ COPY --from=builder /target-rootfs/ /
 
 LABEL containers.bootc 1
 LABEL ostree.bootable 1
-
+RUN bootc container lint --fatal-warnings
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]

--- a/10-kitten/almalinux-10-kitten.yaml
+++ b/10-kitten/almalinux-10-kitten.yaml
@@ -13,6 +13,9 @@ packages:
 postprocess:
   - |
     #!/usr/bin/env bash
+
+    set -euo pipefail
+
     mkdir -p /usr/lib/bootc/install/
     cat > /usr/lib/bootc/install/20-rhel.toml << EOF
     [install]
@@ -20,7 +23,9 @@ postprocess:
     EOF
   - |
     #!/usr/bin/env bash
-    set -xeuo pipefail
+    set -euo pipefail
+    dnf clean all
+    rm /var/{log,cache,lib}/* -rf
     systemctl preset-all
 
 include:

--- a/10/Containerfile
+++ b/10/Containerfile
@@ -9,7 +9,7 @@ COPY --from=repos /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10 /etc/pki/rpm-gpg
 
 COPY 10/almalinux-10.yaml /usr/share/doc/bootc-base-imagectl/manifests/
 
-RUN /usr/libexec/bootc-base-imagectl build-rootfs --manifest=almalinux-10 /target-rootfs
+RUN /usr/libexec/bootc-base-imagectl build-rootfs --reinject --manifest=almalinux-10 /target-rootfs
 
 ###
 
@@ -19,6 +19,6 @@ COPY --from=builder /target-rootfs/ /
 
 LABEL containers.bootc 1
 LABEL ostree.bootable 1
-
+RUN bootc container lint --fatal-warnings
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]

--- a/10/almalinux-10.yaml
+++ b/10/almalinux-10.yaml
@@ -21,12 +21,12 @@ postprocess:
     [install]
     root-fs-type = "xfs"
     EOF
-    
+  - |
+    #!/usr/bin/env bash
+    set -euo pipefail
     dnf clean all
     rm /var/{log,cache,lib}/* -rf
-
-    bootc container lint
-    
+    systemctl preset-all
 
 include:
   - standard/manifest.yaml

--- a/9/Containerfile
+++ b/9/Containerfile
@@ -4,11 +4,12 @@ FROM quay.io/centos-bootc/centos-bootc:stream10 as builder
 RUN rm -rf /etc/yum.repos.d/*
 
 COPY --from=repos /etc/yum.repos.d/*.repo /etc/yum.repos.d/
+
 COPY --from=repos /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9 /etc/pki/rpm-gpg
 
 COPY 9/almalinux-9.yaml /usr/share/doc/bootc-base-imagectl/manifests/
 
-RUN /usr/libexec/bootc-base-imagectl build-rootfs --manifest=almalinux-9 /target-rootfs
+RUN /usr/libexec/bootc-base-imagectl build-rootfs --reinject --manifest=almalinux-9 /target-rootfs
 
 ###
 
@@ -18,6 +19,6 @@ COPY --from=builder /target-rootfs/ /
 
 LABEL containers.bootc 1
 LABEL ostree.bootable 1
-
+RUN bootc container lint --fatal-warnings
 STOPSIGNAL SIGRTMIN+3
 CMD ["/sbin/init"]

--- a/9/almalinux-9.yaml
+++ b/9/almalinux-9.yaml
@@ -21,12 +21,12 @@ postprocess:
     [install]
     root-fs-type = "xfs"
     EOF
-    
+  - |
+    #!/usr/bin/env bash
+    set -euo pipefail
     dnf clean all
     rm /var/{log,cache,lib}/* -rf
-
-    bootc container lint
-    
+    systemctl preset-all
 
 include:
   - standard/manifest.yaml

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,26 @@ IMAGE_NAME = almalinux-bootc
 VERSION_MAJOR = 10
 PLATFORM = linux/amd64
 
+.PHONY: all
+all: rechunk
+
+.PHONY: image
 image:
 	$(PODMAN) build \
 		--platform=$(PLATFORM) \
-        --security-opt=label=disable \
-        --cap-add=all \
-        --device /dev/fuse \
-        -t $(IMAGE_NAME) \
-        -f $(VERSION_MAJOR)/Containerfile \
-        .
+		--security-opt=label=disable \
+		--cap-add=all \
+		--device /dev/fuse \
+		-t $(IMAGE_NAME)-prechunk \
+		-f $(VERSION_MAJOR)/Containerfile \
+		.
+
+.PHONY: rechunk
+rechunk: image
+	$(PODMAN) run \
+		--rm --privileged \
+		-v /var/lib/containers:/var/lib/containers \
+		quay.io/centos-bootc/centos-bootc:stream10 \
+		/usr/libexec/bootc-base-imagectl rechunk \
+		$(IMAGE_NAME)-prechunk $(IMAGE_NAME)
+	-$(PODMAN) rmi $(IMAGE_NAME) $(IMAGE_NAME)-prechunk 2>/dev/null || true


### PR DESCRIPTION
This will make bootc-base-imagectl available in the /usr/libexec/ so that people can use out base images to create their own alma-based ones.

This will also add rechunking into the build pipeline