### PR TITLE
feat: set a lot of labels

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -57,6 +57,7 @@ runs:
         echo "Exit code: '$res'"
 
     - name: Build image
+      id: build
       if: ${{ env.res != 0 || github.event_name == 'workflow_dispatch' }}
       shell: bash
       run: |
@@ -65,10 +66,51 @@ runs:
           IMAGE_NAME=${{ env.IMAGE_NAME }} \
           VERSION_MAJOR=${{ inputs.VERSION_MAJOR }}
 
+        echo "build-time=$(date -Iseconds)" >> $GITHUB_OUTPUT
+
     - name: Run Image
+      id: run
       if: ${{ env.res != 0 || github.event_name == 'workflow_dispatch' }}
       shell: bash
-      run: sudo podman run --rm -ti ${{ env.IMAGE_NAME }} bootc --version
+      run: |
+        sudo podman run --rm -ti ${{ env.IMAGE_NAME }} bootc --version
+
+        INFO=$(sudo podman run --rm ${{ env.IMAGE_NAME }} cat /etc/os-release)
+        echo "$INFO"
+
+        echo "id=$(echo "$INFO" | grep "^ID=" | cut -d'=' -f2 | tr -d '"')" >> $GITHUB_OUTPUT
+        echo "version-id=$(echo "$INFO" | grep "^VERSION_ID=" | cut -d'=' -f2 | tr -d '"')" >> $GITHUB_OUTPUT
+        echo "vendor=$(echo "$INFO" | grep "^VENDOR_NAME=" | cut -d'=' -f2 | tr -d '"')" >> $GITHUB_OUTPUT
+
+    - name: Image Metadata
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+      id: metadata
+      with:
+        images: ${{ env.IMAGE_NAME }}
+        labels: |
+          redhat.id=${{ steps.run.outputs.id }}
+          redhat.version-id=${{ steps.run.outputs.version-id }}
+          version=${{ steps.run.outputs.version-id }}
+          release=${{ steps.run.outputs.version-id }}
+          build-date=${{ steps.build.outputs.build-time }}
+          org.opencontainers.image.created=${{ steps.build.outputs.build-time }}
+          org.opencontainers.image.vendor=${{ steps.run.outputs.vendor }}
+          org.opencontainers.image.version=${{ steps.run.outputs.version-id }}.${{ inputs.DATE_STAMP }}.0
+          org.opencontainers.image.source=${{ github.repositoryUrl }}
+          org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+          org.opencontainers.image.url=${{ github.event.repository.html_url }}
+        annotations: |
+          redhat.id=${{ steps.run.outputs.id }}
+          redhat.version-id=${{ steps.run.outputs.version-id }}
+          version=${{ steps.run.outputs.version-id }}
+          release=${{ steps.run.outputs.version-id }}
+          build-date=${{ steps.build.outputs.build-time }}
+          org.opencontainers.image.created=${{ steps.build.outputs.build-time }}
+          org.opencontainers.image.vendor=${{ steps.run.outputs.vendor }}
+          org.opencontainers.image.version=${{ steps.run.outputs.version-id }}.${{ inputs.DATE_STAMP }}.0
+          org.opencontainers.image.source=${{ github.repositoryUrl }}
+          org.opencontainers.image.title=${{ env.IMAGE_NAME }}
+          org.opencontainers.image.url=${{ github.event.repository.html_url }}
 
     - name: Log in to registry
       if: ${{ env.res != 0 || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
  With the move from `bootc-image-builder` to `bootc-base-imagectl` (#18), we've lost several image labels that were quite useful. This PR adds a whole bunch of labels and annotations to the images.