### PR TITLE
fix: authentication of cosign

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -35,13 +35,12 @@ runs:
         ARCH=${{ matrix.ARCH }}
         echo "CLEAN_ARCH=${ARCH//\//_}" >> "$GITHUB_ENV"
 
-    - name: Log in to registry
-      shell: bash
-      run: |
-        sudo podman login ${{ inputs.IMAGE_REGISTRY }} -u ${{ inputs.REGISTRY_USER }} -p ${{ inputs.REGISTRY_PASSWORD }}
-
-        # This is needed by cosign
-        sudo docker login ${{ inputs.IMAGE_REGISTRY }} -u ${{ inputs.REGISTRY_USER }} -p ${{ inputs.REGISTRY_PASSWORD }}
+    - name: Login in to registry
+      uses: redhat-actions/podman-login@v1 # Also creates $HOME/.docker/config.json, which is used by Cosign for authentication.
+      with:
+        registry: ${{ inputs.IMAGE_REGISTRY }}
+        username: ${{ inputs.REGISTRY_USER }}
+        password: ${{ inputs.REGISTRY_PASSWORD }}
 
     - name: Check update
       shell: bash


### PR DESCRIPTION
The Cosign (v2.5.3) does support Podman's
${XDG_RUNTIME_DIR}/containers/auth.json for reading registry credentials.

This file can be copied as Docker's $HOME/.docker/config.json, since they are in a compatible format.

This workaround can be done using the one of the methods below:
- cp ${XDG_RUNTIME_DIR}/containers/auth.json $HOME/.docker/config.json.
- redhat-actions/podman-login (v1). Which also do the copy operation.