### PR TITLE
Fix CHAT_CHANNEL env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/bootcimages
   KMS_KEY_ALIAS: cloudsig
-  CHAT_CHANNEL: ${{ env.MATTERMOST_CHANNEL }}
+  CHAT_CHANNEL: ${{ vars.MATTERMOST_CHANNEL }}
 
 jobs:
   set-versions-matrix:


### PR DESCRIPTION
Can't use env in the env block, it's got to be `vars` or `secrets`.