### PR TITLE
Fix build failure: remove 'bootc' dracut module from initramfs config

### DIFF
--- a/10/almalinux-10.yaml
+++ b/10/almalinux-10.yaml
@@ -24,6 +24,15 @@ postprocess:
   - |
     #!/usr/bin/env bash
     set -euo pipefail
+    # Remove 'bootc' dracut module from initramfs config
+    # AlmaLinux bootc package does not yet ship the dracut module (requires >= 1.11.0)
+    DRACUT_CONF="/usr/lib/dracut/dracut.conf.d/20-bootc-base.conf"
+    if [ -f "${DRACUT_CONF}" ]; then
+      sed -i 's/ bootc / /' "${DRACUT_CONF}"
+    fi
+  - |
+    #!/usr/bin/env bash
+    set -euo pipefail
     dnf clean all
     rm /var/{log,cache,lib}/* -rf
     systemctl preset-all

--- a/9/almalinux-9.yaml
+++ b/9/almalinux-9.yaml
@@ -24,6 +24,15 @@ postprocess:
   - |
     #!/usr/bin/env bash
     set -euo pipefail
+    # Remove 'bootc' dracut module from initramfs config
+    # AlmaLinux bootc package does not yet ship the dracut module (requires >= 1.11.0)
+    DRACUT_CONF="/usr/lib/dracut/dracut.conf.d/20-bootc-base.conf"
+    if [ -f "${DRACUT_CONF}" ]; then
+      sed -i 's/ bootc / /' "${DRACUT_CONF}"
+    fi
+  - |
+    #!/usr/bin/env bash
+    set -euo pipefail
     dnf clean all
     rm /var/{log,cache,lib}/* -rf
     systemctl preset-all


### PR DESCRIPTION
## Summary

- Upstream [fedora-bootc/base-images](https://gitlab.com/fedora/bootc/base-images) added `bootc` to the dracut modules list in `minimal/initramfs.yaml` ([commit 83ba3346](https://gitlab.com/fedora/bootc/base-images/-/commit/83ba3346ade9fc2fcad0bf09f9011119eb127307)). This module requires `bootc >= 1.11.0`, but AlmaLinux 9 and 10 repos ship `bootc 1.8.0` which does not include the dracut module (`/usr/lib/dracut/modules.d/51bootc/`), causing `dracut[E]: Module 'bootc' cannot be found` during `rpm-ostree compose rootfs`.
- Adds a postprocess step to `9/almalinux-9.yaml` and `10/almalinux-10.yaml` that strips `bootc` from the dracut config (`20-bootc-base.conf`) before initramfs generation.
- 10-kitten is not affected (its repos already ship a newer bootc with the dracut module).

This workaround should be removed once AlmaLinux ships a `bootc` package that includes the dracut module.

Fixes #61

## Test plan

- [ ] Verify nightly CI builds pass for AlmaLinux 9 (amd64, arm64)
- [ ] Verify nightly CI builds pass for AlmaLinux 10 (amd64, arm64, amd64/v2)
- [ ] Verify 10-kitten builds remain unaffected